### PR TITLE
Update radio-stack-version.inc filename

### DIFF
--- a/meta-summit-radio-pre-3.4/recipes-packages/sterling-supplicant/sterling-supplicant-st60.bb
+++ b/meta-summit-radio-pre-3.4/recipes-packages/sterling-supplicant/sterling-supplicant-st60.bb
@@ -1,3 +1,3 @@
 SUMMARY = "Summit Wi-Fi ST60 Sterling Supplicant"
 
-require sterling-supplicant.inc radio-stack-st60-version.inc
+require sterling-supplicant.inc radio-stack-60-version.inc


### PR DESCRIPTION
Is this a mistake or did I miss something? The radio-stack-st60-version.inc file does not exist (but the -60 version does).