### PR TITLE
meta-summit-radio: Add LAYERSERIES_COMPAT

### DIFF
--- a/meta-summit-radio/conf/layer.conf
+++ b/meta-summit-radio/conf/layer.conf
@@ -9,6 +9,8 @@ BBFILE_COLLECTIONS += "summit-radio"
 BBFILE_PATTERN_summit-radio = "^${LAYERDIR}/"
 BBFILE_PRIORITY_summit-radio = "8"
 
+LAYERSERIES_COMPAT_summit-radio = "honister kirkstone langdale mickledore"
+
 BB_DANGLINGAPPENDS_WARNONLY = "1"
 
 PREMIRRORS:prepend = "https://github.com/LairdCP/Sterling-LWB-and-LWB5-Release-Packages/releases/download/.*/.*     file://${TOPDIR}/../release \n"


### PR DESCRIPTION
This PR is an update of #3 onto current head, tested, no edit required

The topic has been discussed on the Yocto mailinglist several times
before. Please consider to comply to the layer guidelines on request
of the community. This helps reducing downstream forks. We are helping
with testing this layer in our CI and will send PRs if we find issues.
Thanks!

see current documentation ->

> Add all supported Yocto versions to the layer.conf. According to the
> documentation, LAYERSERIES_COMPAT is required for yocto layer
> compatibility:
> https://docs.yoctoproject.org/bitbake/2.4/bitbake-user-manual/bitbake-user-manual-ref-variables.html#term-LAYERSERIES_COMPAT

Signed-off-by: Stefan Müller-Klieser <s.mueller-klieser@phytec.de>
