### PR TITLE
license: update NO_GENERIC_LICENSE flag to Ezurio

### DIFF
--- a/meta-summit-radio-pre-3.4/recipes-bsp/radio-firmware/radio-firmware-lwb.inc
+++ b/meta-summit-radio-pre-3.4/recipes-bsp/radio-firmware/radio-firmware-lwb.inc
@@ -2,7 +2,7 @@ require radio-firmware.inc
 require radio-stack-lwb-version.inc
 
 LICENSE = "Ezurio"
-NO_GENERIC_LICENSE[Laird] = "LICENSE"
+NO_GENERIC_LICENSE[Ezurio] = "LICENSE"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=53d3628b28a0bc3caea61587feade5f9"
 
 FILES_${PN} += "${sysconfdir}"

--- a/meta-summit-radio/recipes-bsp/radio-firmware/radio-firmware-lwb.inc
+++ b/meta-summit-radio/recipes-bsp/radio-firmware/radio-firmware-lwb.inc
@@ -1,7 +1,7 @@
 require radio-firmware.inc radio-stack-lwb-version.inc
 
 LICENSE = "Ezurio"
-NO_GENERIC_LICENSE[Laird] = "LICENSE"
+NO_GENERIC_LICENSE[Ezurio] = "LICENSE"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=53d3628b28a0bc3caea61587feade5f9"
 
 FILES:${PN} += "${sysconfdir}"


### PR DESCRIPTION
- this triggers a warning as LICENSE was changed from Laird to Ezurio while NO_GENERIC_LICENSE flag wasn't modified in [1]

[1] - https://github.com/LairdCP/meta-summit-radio/commit/689cc85f4b7e93caf4fe6546cd3ecdbe7954e073

Scarthgap (errors out):
```
ERROR: lwb5plus-usb-sa-firmware-11.171.0.24-r0 do_create_spdx: Cannot find any text for license Ezurio
```

Kirkstone (just warning):
```
WARNING: lwb5plus-usb-sa-firmware-11.171.0.24-r0 do_populate_lic: QA Issue: lwb5plus-usb-sa-firmware: No generic license file exists for: Ezurio in any provider [license-exists]
```