### PR TITLE
Fixed typo in LAYERSERIES_COMPAT_summit-radio-pre-3.4

### DIFF
--- a/meta-summit-radio-pre-3.4/conf/layer.conf
+++ b/meta-summit-radio-pre-3.4/conf/layer.conf
@@ -11,7 +11,7 @@ BBFILE_PRIORITY_summit-radio-pre-3.4 = "8"
 
 RFPROS_FILESHARE_AUTH ?= ""
 
-LAYERSERIES_COMPAT_summit-radio-pre-3.4 = "sumo thud warrior zeus dunfell gategarth hardknott"
+LAYERSERIES_COMPAT_summit-radio-pre-3.4 = "sumo thud warrior zeus dunfell gatesgarth hardknott"
 
 BB_DANGLINGAPPENDS_WARNONLY = "1"
 


### PR DESCRIPTION
Gatesgarth misspelled.

https://wiki.yoctoproject.org/wiki/Releases